### PR TITLE
Added stencil border handling

### DIFF
--- a/LibSymd/LibSymd.vcxproj
+++ b/LibSymd/LibSymd.vcxproj
@@ -97,6 +97,7 @@
     <ClInclude Include="include\internal\symd_register.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="test_stencil_borders.cpp" />
     <ClCompile Include="test_symd.cpp" />
     <ClCompile Include="test_symd_register.cpp" />
   </ItemGroup>

--- a/LibSymd/LibSymd.vcxproj
+++ b/LibSymd/LibSymd.vcxproj
@@ -95,6 +95,7 @@
     <ClInclude Include="include\internal\sub_view.h" />
     <ClInclude Include="include\symd.h" />
     <ClInclude Include="include\internal\symd_register.h" />
+    <ClInclude Include="test_helpers.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="test_stencil_borders.cpp" />

--- a/LibSymd/LibSymd.vcxproj.filters
+++ b/LibSymd/LibSymd.vcxproj.filters
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ClCompile Include="test_symd.cpp" />
     <ClCompile Include="test_symd_register.cpp" />
+    <ClCompile Include="test_stencil_borders.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\symd.h">

--- a/LibSymd/LibSymd.vcxproj.filters
+++ b/LibSymd/LibSymd.vcxproj.filters
@@ -33,6 +33,7 @@
     <ClInclude Include="include\internal\reduce_view.h">
       <Filter>include\internal</Filter>
     </ClInclude>
+    <ClInclude Include="test_helpers.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="include">

--- a/LibSymd/include/internal/stencil_view.h
+++ b/LibSymd/include/internal/stencil_view.h
@@ -24,13 +24,13 @@ namespace symd::__internal__
         Border _borderHandling;
         C _borderConstant;
 
-        Stencil(View&& view, int width, int height, Border borderHandling = Border::mirror, C c = C(0))
+        Stencil(View&& view, int width, int height, Border borderHandling = Border::mirror, C borderConstant = C(0))
             : _underlyingView(std::forward<View>(view))
             , _width(width)
             , _height(height)
         {
             _borderHandling = borderHandling;
-            _borderConstant = c;
+            _borderConstant = borderConstant;
         }
     };
 
@@ -94,7 +94,7 @@ namespace symd::__internal__
     public:
         using UnderlyingDataType = std::decay_t<decltype(fetchData(_underlyingView, 0, 0))>;
 
-        StencilPix(const View& view, size_t row, size_t col, Border borderHandling, C c)
+        StencilPix(const View& view, size_t row, size_t col, Border borderHandling, C borderConstant)
             : _underlyingView(view)
             , _row(row)
             , _col(col)
@@ -103,7 +103,7 @@ namespace symd::__internal__
             _underlyingHeight = getHeight(_underlyingView);
 
             _borderHandling = borderHandling;            
-            _borderConstant = c;
+            _borderConstant = borderConstant;
         }
 
         UnderlyingDataType operator()(int dr, int dc) const
@@ -111,9 +111,8 @@ namespace symd::__internal__
             auto row = (int64_t)_row + dr;
             auto col = (int64_t)_col + dc;
 
-            // TODO: First cast then sub?
-            const auto heightLimit = (int64_t)(_underlyingHeight - 1);
-            const auto widthLimit = (int64_t)(_underlyingWidth - 1);
+            const auto heightLimit = (int64_t)(_underlyingHeight) - 1;
+            const auto widthLimit = (int64_t)(_underlyingWidth) - 1;
 
             switch (_borderHandling)
             {
@@ -175,7 +174,6 @@ namespace symd::__internal__
         }
     };
 
-
     template <typename View, typename C>
     size_t getWidth(const Stencil<View, C>& x)
     {
@@ -218,7 +216,6 @@ namespace symd::__internal__
         return (st._height / 2) + verticalBorder(st._underlyingView);
     }
 }
-
 
 namespace symd::views
 {

--- a/LibSymd/test_helpers.h
+++ b/LibSymd/test_helpers.h
@@ -1,0 +1,312 @@
+#pragma once
+#include "catch.h"
+#include "include/symd.h"
+#include <chrono>
+#include <algorithm>
+#include <random>
+
+using namespace symd::__internal__;
+
+namespace tests
+{
+    /////////////////////////////////////////////////////////////////////////////////////////
+/// Helper functions
+/////////////////////////////////////////////////////////////////////////////////////////
+
+    template <typename T>
+    static bool isRegEqualToData(const SymdRegister<T>& reg, const std::vector<T>& reference)
+    {
+        std::vector<T> tmpRes(SYMD_LEN + 2);
+        tmpRes[0] = (T)0;
+        tmpRes[SYMD_LEN + 1] = (T)0;
+
+        reg.store(tmpRes.data() + 1);
+
+        // Does not overwrite nearby locations
+        REQUIRE(tmpRes[0] == (T)0);
+        REQUIRE(tmpRes[SYMD_LEN + 1] == (T)0);
+
+        for (size_t i = 0; i < SYMD_LEN; i++)
+        {
+            if (reg[i] != reference[i])
+                return false;
+
+            // Check store as well
+            if (tmpRes[i + 1] != reference[i])
+                return false;
+        }
+
+        return true;
+    }
+
+    template <typename T>
+    static bool isRegCmpValid(const SymdRegister<T>& reg, const std::vector<bool>& reference)
+    {
+        std::vector<T> tmpRes(SYMD_LEN + 2);
+        tmpRes[0] = (T)0;
+        tmpRes[SYMD_LEN + 1] = (T)0;
+
+        reg.store(tmpRes.data() + 1);
+
+        // Does not overwrite nearby locations
+        REQUIRE(tmpRes[0] == (T)0);
+        REQUIRE(tmpRes[SYMD_LEN + 1] == (T)0);
+
+        for (std::size_t i = 0; i < SYMD_LEN; i++)
+        {
+            // FLOATS
+            if constexpr (std::is_floating_point_v<T>)
+            {
+                if (reference[i] && !std::isnan(reg[i]))
+                    return false;
+                else if (!reference[i] && std::isnan(reg[i]))
+                    return false;
+
+                // Check store as well
+                if (reference[i] && !std::isnan(tmpRes[i + 1]))
+                    return false;
+                else if (!reference[i] && std::isnan(tmpRes[i + 1]))
+                    return false;
+            }
+            // INTS
+            else if constexpr (std::is_integral_v<T>)
+            {
+                if (reference[i] && reg[i] != -1)
+                    return false;
+                else if (!reference[i] && reg[i] != 0)
+                    return false;
+
+                // Check store as well
+                if (reference[i] && tmpRes[i + 1] != -1)
+                    return false;
+                else if (!reference[i] && tmpRes[i + 1] != 0)
+                    return false;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+
+    template <typename T, typename Operation>
+    std::vector<T> applyOpToVector(const std::vector<T>& in, Operation&& op, T x)
+    {
+        std::vector<T> reference(in.size());
+
+        for (size_t i = 0; i < in.size(); i++)
+            reference[i] = op(in[i], x);
+
+        return reference;
+    }
+
+
+    template <typename T, typename Operation>
+    std::vector<T> applyOpToVector(T x, Operation&& op, const std::vector<T>& in)
+    {
+        std::vector<T> reference(in.size());
+
+        for (size_t i = 0; i < in.size(); i++)
+            reference[i] = op(x, in[i]);
+
+        return reference;
+    }
+
+
+    template <typename T, typename Operation>
+    std::vector<T> applyOpToVector(const std::vector<T>& in1, Operation&& op, const std::vector<T>& in2)
+    {
+        std::vector<T> reference(in1.size());
+
+        for (size_t i = 0; i < in1.size(); i++)
+            reference[i] = op(in1[i], in2[i]);
+
+        return reference;
+    }
+
+
+    template <typename T, typename Operation>
+    static void checkOperationResult(const std::vector<T>& in1, Operation&& op, const std::vector<T>& in2)
+    {
+        REQUIRE(in1.size() == in2.size());
+
+        SymdRegister<T> reg1(in1.data());
+        SymdRegister<T> reg2(in2.data());
+
+        REQUIRE(isRegEqualToData(reg1, in1));
+        REQUIRE(isRegEqualToData(reg2, in2));
+
+        SymdRegister<T> res = op(reg1, reg2);
+        std::vector<T> reference(in1.size());
+
+        for (size_t i = 0; i < in1.size(); i++)
+            reference[i] = op(in1[i], in2[i]);
+
+        REQUIRE(isRegEqualToData(res, reference));
+    }
+
+
+    template <typename T, typename Operation>
+    static void checkUnaryOperationResult(Operation&& op, const std::vector<T>& in)
+    {
+        SymdRegister<T> reg(in.data());
+        REQUIRE(isRegEqualToData(reg, in));
+
+        SymdRegister<T> res = op(reg);
+        std::vector<T> reference(in.size());
+
+        for (size_t i = 0; i < in.size(); i++)
+            reference[i] = op(in[i]);
+
+        REQUIRE(isRegEqualToData(res, reference));
+    }
+
+
+    template <typename T, typename Operation>
+    static void checkCmpOperationResult(const std::vector<T>& in1, Operation&& op, const std::vector<T>& in2)
+    {
+        REQUIRE(in1.size() == in2.size());
+
+        SymdRegister<T> reg1(in1.data());
+        SymdRegister<T> reg2(in2.data());
+
+        REQUIRE(isRegEqualToData(reg1, in1));
+        REQUIRE(isRegEqualToData(reg2, in2));
+
+        SymdRegister<T> res = op(reg1, reg2);
+        std::vector<bool> reference(in1.size());
+
+        for (std::size_t i = 0; i < in1.size(); i++)
+            reference[i] = op(in1[i], in2[i]);
+
+        REQUIRE(isRegCmpValid(res, reference));
+    }
+
+    template <typename BitOperation>
+    static auto floatingPointBitOp(BitOperation&& bOp)
+    {
+        auto bOpRes = [&bOp](auto&& lhs, auto&& rhs)
+        {
+            using T = std::decay_t<decltype(lhs)>;
+            using U = std::decay_t<decltype(rhs)>;
+            static_assert(std::is_same_v<T, U>);
+
+            if constexpr (std::is_floating_point_v<T>)
+            {
+                using ResType = typename std::conditional<std::is_same_v<T, float>, uint32_t, uint64_t>::type;
+
+                auto* lhs_ = reinterpret_cast<const ResType*>(&lhs);
+                auto* rhs_ = reinterpret_cast<const ResType*>(&rhs);
+
+                ResType res = bOp(*lhs_, *rhs_);
+
+                return *reinterpret_cast<T*>(&res);
+            }
+            else
+            {
+                // This is a SymdRegister.
+                return bOp(rhs, lhs);
+            }
+        };
+
+        return bOpRes;
+    }
+
+    template <typename BitOperation>
+    static decltype(auto) floatingPointBitUnaryOp(BitOperation&& uBOp)
+    {
+        auto uBOpRes = [&uBOp](auto&& arg)
+        {
+            using T = std::decay_t<decltype(arg)>;
+
+            if constexpr (std::is_floating_point_v<T>)
+            {
+                using ResType = typename std::conditional<std::is_same_v<T, float>, uint32_t, uint64_t>::type;
+
+                auto* arg_ = reinterpret_cast<const ResType*>(&arg);
+                ResType res = uBOp(*arg_);
+
+                return *reinterpret_cast<T*>(&res);
+            }
+            else
+            {
+                // This is a SymdRegister.
+                return uBOp(arg);
+            }
+        };
+
+        return uBOpRes;
+    }
+
+    /// <summary>
+    /// Fills input vector with random floats in range 0-255
+    /// </summary>
+    static void randomizeData(std::vector<float>& data)
+    {
+        std::default_random_engine generator;
+        std::uniform_real_distribution<float> distribution(0.f, 255.f);
+
+        for (auto& x : data)
+            x = distribution(generator);
+    }
+
+    /// <summary>
+    /// Fills input vector with random ints in range 0-255
+    /// </summary>
+    static void randomizeData(std::vector<int>& data)
+    {
+        std::default_random_engine generator;
+        std::uniform_int_distribution<int> distribution(0, 255);
+
+        for (auto& x : data)
+            x = distribution(generator);
+    }
+
+    template <typename T>
+    static void requireEqual(const T* data, const std::vector<T>& ref)
+    {
+        for (size_t i = 0; i < ref.size(); i++)
+            REQUIRE(data[i] == ref[i]);
+    }
+
+    template <typename T>
+    static void requireEqual(const std::vector<T>& data, const std::vector<T>& ref)
+    {
+        REQUIRE(data.size() == ref.size());
+
+        requireEqual(data.data(), ref);
+    }
+
+    template <typename T>
+    static void requireNear(const std::vector<T>& data, const std::vector<T>& ref, T eps)
+    {
+        REQUIRE(data.size() == ref.size());
+
+        for (size_t i = 0; i < ref.size(); i++)
+            REQUIRE(std::abs(data[i] - ref[i]) < eps);
+    }
+
+    template <typename StencilView, typename DataType>
+    auto conv3x3_Kernel(const StencilView& sv, const DataType* kernel)
+    {
+        return
+            sv(-1, -1) * kernel[0] + sv(-1, 0) * kernel[1] + sv(-1, 1) * kernel[2] +
+            sv(0, -1) * kernel[3] + sv(0, 0) * kernel[4] + sv(0, 1) * kernel[5] +
+            sv(1, -1) * kernel[6] + sv(1, 0) * kernel[7] + sv(1, 1) * kernel[8];
+    }
+
+    template <typename StencilView, typename DataType>
+    auto conv5x5_Kernel(const StencilView& sv, const DataType* kernel)
+    {
+        return
+            sv(-2, -2) * kernel[0] + sv(-2, -1) * kernel[1] + sv(-2, 0) * kernel[2] + sv(-2, 1) * kernel[3] + sv(-2, 2) * kernel[4] +
+            sv(-1, -2) * kernel[5] + sv(-1, -1) * kernel[6] + sv(-1, 0) * kernel[7] + sv(-1, 1) * kernel[8] + sv(-1, 2) * kernel[9] +
+            sv(0, -2) * kernel[10] + sv(0, -1) * kernel[11] + sv(0, 0) * kernel[12] + sv(0, 1) * kernel[13] + sv(0, 2) * kernel[14] +
+            sv(1, -2) * kernel[15] + sv(1, -1) * kernel[16] + sv(1, 0) * kernel[17] + sv(1, 1) * kernel[18] + sv(1, 2) * kernel[19] +
+            sv(2, -2) * kernel[20] + sv(2, -1) * kernel[21] + sv(2, 0) * kernel[22] + sv(2, 1) * kernel[23] + sv(2, 2) * kernel[24];
+    }
+
+}

--- a/LibSymd/test_stencil_borders.cpp
+++ b/LibSymd/test_stencil_borders.cpp
@@ -1,41 +1,7 @@
-#include "catch.h"
-#include "include/symd.h"
-#include <iostream>
+#include "test_helpers.h"
 
 namespace tests
 {
-    // TODO: Repeated from test_symd.cpp, do something about it.
-    template <typename StencilView, typename DataType>
-    auto conv3x3_Kernel(const StencilView& sv, const DataType* kernel)
-    {
-        return
-            sv(-1, -1) * kernel[0] + sv(-1, 0) * kernel[1] + sv(-1, 1) * kernel[2] +
-            sv(0, -1) * kernel[3] + sv(0, 0) * kernel[4] + sv(0, 1) * kernel[5] +
-            sv(1, -1) * kernel[6] + sv(1, 0) * kernel[7] + sv(1, 1) * kernel[8];
-    }
-
-    template <typename StencilView, typename DataType>
-    auto conv5x5_Kernel(const StencilView& sv, const DataType* kernel)
-    {
-        return
-            sv(-2, -2) * kernel[0] + sv(-2, -1) * kernel[1] + sv(-2, 0) * kernel[2] + sv(-2, 1) * kernel[3] + sv(-2, 2) * kernel[4] +
-            sv(-1, -2) * kernel[5] + sv(-1, -1) * kernel[6] + sv(-1, 0) * kernel[7] + sv(-1, 1) * kernel[8] + sv(-1, 2) * kernel[9] +
-            sv(0, -2) * kernel[10] + sv(0, -1) * kernel[11] + sv(0, 0) * kernel[12] + sv(0, 1) * kernel[13] + sv(0, 2) * kernel[14] +
-            sv(1, -2) * kernel[15] + sv(1, -1) * kernel[16] + sv(1, 0) * kernel[17] + sv(1, 1) * kernel[18] + sv(1, 2) * kernel[19] +
-            sv(2, -2) * kernel[20] + sv(2, -1) * kernel[21] + sv(2, 0) * kernel[22] + sv(2, 1) * kernel[23] + sv(2, 2) * kernel[24];
-    }
-
-
-    // TODO: Repeated from test_symd.cpp, do something about it.
-    template <typename T>
-    static void requireNear(const std::vector<T>& data, const std::vector<T>& ref, T eps)
-    {
-        REQUIRE(data.size() == ref.size());
-
-        for (size_t i = 0; i < ref.size(); i++)
-            REQUIRE(std::abs(data[i] - ref[i]) < eps);
-    }
-
     static constexpr std::array<float, 9> kernel3x3 = {
         1, 0, -1,
         2, 0, -2,

--- a/LibSymd/test_stencil_borders.cpp
+++ b/LibSymd/test_stencil_borders.cpp
@@ -1,9 +1,6 @@
 #include "catch.h"
-#include <iostream>
 #include "include/symd.h"
-#include <chrono>
-#include <algorithm>
-#include <random>
+#include <iostream>
 
 namespace tests
 {
@@ -17,6 +14,18 @@ namespace tests
             sv(1, -1) * kernel[6] + sv(1, 0) * kernel[7] + sv(1, 1) * kernel[8];
     }
 
+    template <typename StencilView, typename DataType>
+    auto conv5x5_Kernel(const StencilView& sv, const DataType* kernel)
+    {
+        return
+            sv(-2, -2) * kernel[0] + sv(-2, -1) * kernel[1] + sv(-2, 0) * kernel[2] + sv(-2, 1) * kernel[3] + sv(-2, 2) * kernel[4] +
+            sv(-1, -2) * kernel[5] + sv(-1, -1) * kernel[6] + sv(-1, 0) * kernel[7] + sv(-1, 1) * kernel[8] + sv(-1, 2) * kernel[9] +
+            sv(0, -2) * kernel[10] + sv(0, -1) * kernel[11] + sv(0, 0) * kernel[12] + sv(0, 1) * kernel[13] + sv(0, 2) * kernel[14] +
+            sv(1, -2) * kernel[15] + sv(1, -1) * kernel[16] + sv(1, 0) * kernel[17] + sv(1, 1) * kernel[18] + sv(1, 2) * kernel[19] +
+            sv(2, -2) * kernel[20] + sv(2, -1) * kernel[21] + sv(2, 0) * kernel[22] + sv(2, 1) * kernel[23] + sv(2, 2) * kernel[24];
+    }
+
+
     // TODO: Repeated from test_symd.cpp, do something about it.
     template <typename T>
     static void requireNear(const std::vector<T>& data, const std::vector<T>& ref, T eps)
@@ -27,38 +36,51 @@ namespace tests
             REQUIRE(std::abs(data[i] - ref[i]) < eps);
     }
 
-    static constexpr float epsilon = 0.03f;
-
     static constexpr std::array<float, 9> kernel3x3 = {
         1, 0, -1,
         2, 0, -2,
         1, 0, -1
     };
 
-    //static constexpr std::array<float, 25> kernel5x5 = {
-    //    2,  2,  4,  2,  2,
-    //    1,  1,  2,  1,  1,
-    //    0,  0,  0,  0,  0,
-    //   -1, -1, -2, -1, -1,
-    //   -2, -2, -4, -2, -2
-    //};
+    static constexpr std::array<float, 25> kernel5x5 = {
+        2,  2,  4,  2,  2,
+        1,  1,  2,  1,  1,
+        0,  0,  0,  0,  0,
+       -1, -1, -2, -1, -1,
+       -2, -2, -4, -2, -2
+    };
 
     static std::vector<float> input { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21 };
 
     struct SBTestData 
     {
+        std::string name;
+
+        int kernelSize;
         symd::Border border;
         float C;
         std::vector<float> expected_output;
     };
 
-    TEST_CASE("Stencil - Border Test Cases")
+    TEST_CASE("Stencil - Border Types Test Cases")
     {
-        auto [border, C, expected_output] = GENERATE(
-            SBTestData { symd::Border::mirror, 0.0f, { 0, -8, -8, 0, 0, -8, -8, 0, 0, -8, -8, 0, 0, -8, -8, 0, 0, -8, -8, 0 } },
-            SBTestData { symd::Border::constant, 0.0f, { -10, -6, -6, 13, -24, -8, -8, 28, -40, -8, -8, 44, -57, -8, -8, 61, -52, -6, -6, 55 } },
-            SBTestData { symd::Border::constant, 13.0f, { 29, -6, -6, -26, 28, -8, -8, -24, 12, -8, -8, -8, -5, -8, -8, 9, -13, -6, -6, 16 } }
+        auto [name, kernelSize, border, C, expected_output] = GENERATE(
+            // 3x3 Kernel Test Cases
+            SBTestData { "3x3 - mirror",           3, symd::Border::mirror, 0.0f, { 0, -8, -8, 0, 0, -8, -8, 0, 0, -8, -8, 0, 0, -8, -8, 0, 0, -8, -8, 0 } },
+            SBTestData { "3x3 - constant=0",       3, symd::Border::constant, 0.0f, { -10, -6, -6, 13, -24, -8, -8, 28, -40, -8, -8, 44, -57, -8, -8, 61, -52, -6, -6, 55 } },
+            SBTestData { "3x3 - constant=13",      3, symd::Border::constant, 13.0f, { 29, -6, -6, -26, 28, -8, -8, -24, 12, -8, -8, -8, -5, -8, -8, 9, -13, -6, -6, 16 } },
+            SBTestData { "3x3 - replicate",        3, symd::Border::replicate, 0.0f, { -4, -8, -8, -4, -4, -8, -8, -4, -4, -8, -8, -4, -4, -8, -8, -4, -4, -8, -8, -4 } },
+            SBTestData { "3x3 - mirror_replicate", 3, symd::Border::mirror_replicate, 0.0f, { -4, -8, -8, -4, -4, -8, -8, -4, -4, -8, -8, -4, -4, -8, -8, -4, -4, -8, -8, -4 } },
+            // 5x5 Kernel Test Cases
+            SBTestData { "5x5 - mirror",           5, symd::Border::mirror, 0.0f, { 0, 0, 0, 0, -144, -144, -144, -144, -252, -252, -252, -252, -150, -150, -150, -150, 0, 0, 0, 0 } },
+            SBTestData { "5x5 - constant=0",       5, symd::Border::constant, 0.0f, { -101, -136, -139, -119, -142, -184, -186, -154, -168, -210, -210, -168, 10, 19, 21, 22, 133, 176, 179, 151 } },
+            SBTestData { "5x5 - constant=5",       5, symd::Border::constant, 5.0f, { -41, -61, -64, -59, -102, -134, -136, -114, -168, -210, -210, -168, -30, -31, -29, -18, 73, 101, 104, 91 } },
+            SBTestData { "5x5 - replicate",        5, symd::Border::replicate, 0.0f, { -120, -120, -120, -120, -192, -192, -192, -192, -252, -252, -252, -252, -210, -210, -210, -210, -138, -138, -138, -138 } },
+            SBTestData { "5x5 - mirror_replicate", 5, symd::Border::mirror_replicate, 0.0f, { -72, -72, -72, -72, -192, -192, -192, -192, -252, -252, -252, -252, -210, -210, -210, -210, -78, -78, -78, -78 } }
         );
+
+        // Logged on failure only
+        INFO("Test Case: " + name);
 
         // Prepare 2D view to data to do 2D convolution
         symd::views::data_view<float, 2> input_2d(input.data(), 4, 5, 4);
@@ -66,12 +88,24 @@ namespace tests
         std::vector<float> output(input.size());
         symd::views::data_view<float, 2> output_2d(output.data(), 4, 5, 4);
 
-        // Do the convolution. We also need 2D stencil view
-        symd::map(output_2d, [&](const auto& x)
-            {
-                return conv3x3_Kernel(x, kernel3x3.data());
+        if (kernelSize == 3) 
+        {
+            // Do the 3x3 convolution. We also need 2D stencil view
+            symd::map(output_2d, [&](const auto& x)
+                {
+                    return conv3x3_Kernel(x, kernel3x3.data());
 
-            }, symd::views::stencil(input_2d, 3, 3, border, C));
+                }, symd::views::stencil(input_2d, 3, 3, border, C));
+        }
+        else
+        {
+            // Do the 5x5 convolution. We also need 2D stencil view
+            symd::map(output_2d, [&](const auto& x)
+                {
+                    return conv5x5_Kernel(x, kernel5x5.data());
+
+                }, symd::views::stencil(input_2d, 5, 5, border, C));
+        }
 
         // Verify
         requireNear(output, expected_output, 0.03f);

--- a/LibSymd/test_stencil_borders.cpp
+++ b/LibSymd/test_stencil_borders.cpp
@@ -1,0 +1,76 @@
+#include "catch.h"
+#include <iostream>
+#include "include/symd.h"
+#include <chrono>
+#include <algorithm>
+#include <random>
+
+namespace tests
+{
+    // TODO: Repeated from test_symd.cpp, do something about it.
+    template <typename StencilView, typename DataType>
+    auto conv3x3_Kernel(const StencilView& sv, const DataType* kernel)
+    {
+        return
+            sv(-1, -1) * kernel[0] + sv(-1, 0) * kernel[1] + sv(-1, 1) * kernel[2] +
+            sv(0, -1) * kernel[3] + sv(0, 0) * kernel[4] + sv(0, 1) * kernel[5] +
+            sv(1, -1) * kernel[6] + sv(1, 0) * kernel[7] + sv(1, 1) * kernel[8];
+    }
+
+    // TODO: Repeated from test_symd.cpp, do something about it.
+    template <typename T>
+    static void requireNear(const std::vector<T>& data, const std::vector<T>& ref, T eps)
+    {
+        REQUIRE(data.size() == ref.size());
+
+        for (size_t i = 0; i < ref.size(); i++)
+            REQUIRE(std::abs(data[i] - ref[i]) < eps);
+    }
+
+    TEST_CASE("Stencil - Border Type Mirror")
+    {
+        std::vector<float> input { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21 };
+
+        // Kernel for convolution
+        std::array<float, 9> kernel = {
+             0,    -1.f,    0,
+            -1.f,   4.f,   -1.f,
+             0,    -1.f,    0
+        };
+
+        // Prepare 2D view to data to do 2D convolution
+        symd::views::data_view<float, 2> input_2d(input.data(), 4, 5, 4);
+
+        std::vector<float> output(input.size());
+        symd::views::data_view<float, 2> output_2d(output.data(), 4, 5, 4);
+
+        symd::map(output_2d, [&](const auto& x)
+            {
+                return conv3x3_Kernel(x, kernel.data());
+
+            }, symd::views::stencil(input_2d, 3, 3));
+
+        std::vector<float> expected_output { -10.0f, -8.0f, -8.0f, -6.0f,
+                                             -2.0f, 0.0f, 0.0f, 2.0f,
+                                             -2.0f, 0.0f, 0.0f, 2.0f,
+                                             -3.0f, -1.0f, -1.0f, 1.0f,
+                                              8.0f, 10.0f, 10.0f, 12.0f };
+
+        requireNear(output, expected_output, 0.03f);
+    }
+
+    // GENERATOS example!
+    //struct TestData
+    //{
+    //    Position startPos;
+    //    Position expectedMove;
+    //};
+
+    //TEST_CASE("Test legal moves on empty 2x1 board")
+    //{
+    //    Board board{ 2, 1 };
+    //    auto testData = GENERATE(TestData{ {0, 0}, {1, 0} }, TestData{ {1, 0}, {0, 0} });
+    //    auto lagalMoves = board.getLegalMoves(testData.startPos);
+    //    REQUIRE(lagalMoves[0] == testData.expectedMove);
+    //}
+}

--- a/LibSymd/test_symd.cpp
+++ b/LibSymd/test_symd.cpp
@@ -468,8 +468,8 @@ namespace tests
 
         auto readMirror = [&](int i, int j)
         {
-            auto ii = symd::__internal__::foldCoords(i, 0, height - 1);
-            auto jj = symd::__internal__::foldCoords(j, 0, width - 1);
+            auto ii = symd::__internal__::mirrorCoords(i, 0, height - 1);
+            auto jj = symd::__internal__::mirrorCoords(j, 0, width - 1);
 
             return input_2d.readPix(ii, jj);
         };

--- a/LibSymd/test_symd.cpp
+++ b/LibSymd/test_symd.cpp
@@ -1,10 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.h"
-#include <iostream>
-#include "include/symd.h"
-#include <chrono>
-#include <algorithm>
-#include <random>
+#include "test_helpers.h"
 
 
 namespace tests
@@ -18,54 +13,6 @@ namespace tests
 #else
     constexpr int NUM_ITER = 100;
 #endif
-
-    /// <summary>
-    /// Fills input vector with random floats in range 0-255
-    /// </summary>
-    void randomizeData(std::vector<float>& data)
-    {
-        std::default_random_engine generator;
-        std::uniform_real_distribution<float> distribution(0.f, 255.f);
-
-        for (auto& x : data)
-            x = distribution(generator);
-    }
-
-    /// <summary>
-    /// Fills input vector with random ints in range 0-255
-    /// </summary>
-    void randomizeData(std::vector<int>& data)
-    {
-        std::default_random_engine generator;
-        std::uniform_int_distribution<int> distribution(0, 255);
-
-        for (auto& x : data)
-            x = distribution(generator);
-    }
-
-    template <typename T>
-    static void requireEqual(const T* data, const std::vector<T>& ref)
-    {
-        for (size_t i = 0; i < ref.size(); i++)
-            REQUIRE(data[i] == ref[i]);
-    }
-
-    template <typename T>
-    static void requireEqual(const std::vector<T>& data, const std::vector<T>& ref)
-    {
-        REQUIRE(data.size() == ref.size());
-
-        requireEqual(data.data(), ref);
-    }
-
-    template <typename T>
-    static void requireNear(const std::vector<T>& data, const std::vector<T>& ref, T eps)
-    {
-        REQUIRE(data.size() == ref.size());
-
-        for (size_t i = 0; i < ref.size(); i++)
-            REQUIRE(std::abs(data[i] - ref[i]) < eps);
-    }
 
     /// <summary>
     /// Executes input function for number of times and returns average execution time in ms.
@@ -407,15 +354,6 @@ namespace tests
 
         // Calculate image gradient. We also need 2D stencil view.
         symd::map(twoDOutput, [&](const auto& sv) { return sv(0, 1) - sv(0, -1); }, symd::views::stencil(twoDInput, 3, 3));
-    }
-
-    template <typename StencilView, typename DataType>
-    auto conv3x3_Kernel(const StencilView& sv, const DataType* kernel)
-    {
-        return
-            sv(-1, -1) * kernel[0] + sv(-1, 0) * kernel[1] + sv(-1, 1) * kernel[2] +
-            sv(0, -1) * kernel[3] + sv(0, 0) * kernel[4] + sv(0, 1) * kernel[5] +
-            sv(1, -1) * kernel[6] + sv(1, 0) * kernel[7] + sv(1, 1) * kernel[8];
     }
 
     TEST_CASE("Mapping - Convolucion 3x3")


### PR DESCRIPTION
1. Added border handling for stencil view:
- constant
- replicate
- mirror_replicate
- mirror (was already implemented, only changed the function name).

2. Added tests that cover all border handlings using 3x3 and 5x5 convolution.

3. Moved test helper functions to a separate file.
